### PR TITLE
Add lint keyword to namespaces list

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,6 +22,7 @@ export const NAMESPACES = [
 	"build",
 	"dev",
 	"format",
+	"lint",
 	"other",
 	"report",
 	"setup",


### PR DESCRIPTION
It's used a lot, would be nice to see it as a default one.

Some examples:

- [airbnb](https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v18.1.0/package.json#L10)
- [react](https://github.com/facebook/react/blob/v16.13.1/package.json#L105)
- [vue](https://github.com/vuejs/vue/blob/v2.6.11/package.json#L37)